### PR TITLE
Remove decorative soulforge and replace it by Dupeitem

### DIFF
--- a/items/i_profession.scp
+++ b/items/i_profession.scp
@@ -3093,15 +3093,9 @@ DUPEITEM=044c7
 //Small Soulforge
 DUPEITEM=044c7
 
-[itemdef 044CA]
-defname=i_small_soul_forge
-name=small sould forge
-RESOURCES=4 i_floor_marble
-CATEGORY=Decoration - High Seas
-SUBSECTION=Forge
-DESCRIPTION=small sould forge
-DUPELIST=044c7
-
+[ITEMDEF 044ca]
+//Small Soulforge
+DUPEITEM=044c7
 
 [ITEMDEF 044cb]
 DEFNAME=i_lobster_buoy


### PR DESCRIPTION
We should code it like this?
Why someone just added a decorative soulforge item without type?
044CA is just a frame of the real soulforge 